### PR TITLE
fix g-s-s.py locking : only remove the lockfile if we have the lock

### DIFF
--- a/scripts/glance-simplestreams-sync.py
+++ b/scripts/glance-simplestreams-sync.py
@@ -454,7 +454,6 @@ def main():
     log.info("glance-simplestreams-sync started.")
 
     lockfile = open(SYNC_RUNNING_FLAG_FILE_NAME, 'w')
-    atexit.register(cleanup)
 
     try:
         fcntl.flock(lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -462,6 +461,7 @@ def main():
         log.info("{} is locked, exiting".format(SYNC_RUNNING_FLAG_FILE_NAME))
         sys.exit(0)
 
+    atexit.register(cleanup)
     lockfile.write(str(os.getpid()))
 
     id_conf, charm_conf = get_conf()


### PR DESCRIPTION
Fixes LP#1766881

Without this, a run that detects a lock will remove the lockfile, so the next run will happily run because the lockfile is gone.